### PR TITLE
fix: createGeometryFromData Polygon

### DIFF
--- a/src/polygon/polygon.ts
+++ b/src/polygon/polygon.ts
@@ -51,6 +51,13 @@ export default class Polygon extends Base {
     this.drawPolygon();
   }
 
+  createGraphic(positions: Cartesian3[]) {
+    const lnglatPoints = positions.map(this.cartesianToLnglat);
+    const coords = lnglatPoints.flat();
+    const cartesianPoints = this.cesium.Cartesian3.fromDegreesArray(coords);
+    return cartesianPoints;
+  }
+
   getPoints() {
     return this.points;
   }


### PR DESCRIPTION
Polygon 类实现Base的createGraphic方法，解决createGeometryFromData图形为Polygon报错的问题。