### PR TITLE
fix: createGeometryFromData Polygon

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -870,6 +870,7 @@ export default class Base {
 
   createGraphic(points: CesiumTypeOnly.Cartesian3[]): CesiumTypeOnly.Cartesian3[] {
     //Abstract method that must be implemented by subclasses.
-    return [new this.cesium.Cartesian3()];
+    // return [new this.cesium.Cartesian3()];
+	return points;
   }
 }

--- a/src/polygon/polygon.ts
+++ b/src/polygon/polygon.ts
@@ -51,6 +51,13 @@ export default class Polygon extends Base {
     this.drawPolygon();
   }
 
+  createGraphic(positions: Cartesian3[]) {
+    const lnglatPoints = positions.map(this.cartesianToLnglat);
+    const coords = lnglatPoints.flat();
+    const cartesianPoints = this.cesium.Cartesian3.fromDegreesArray(coords);
+    return cartesianPoints;
+  }
+
   getPoints() {
     return this.points;
   }


### PR DESCRIPTION
1、 调整Base类的 createGraphic 方法返回值（根据作者建议完善Base类的createGraphic方法的return）；
2、Polygon类实现Base类的 createGraphic 方法，修复图形回显bug。